### PR TITLE
Better handling of missing values for some UPS

### DIFF
--- a/client/src/runtime.tsx
+++ b/client/src/runtime.tsx
@@ -2,6 +2,10 @@ import Kpi from './kpi';
 
 function secondsToDhms(seconds: number) {
   seconds = Number(seconds);
+  if (seconds === 0) {
+    return 'N/A';
+  }
+
   const d = Math.floor(seconds / (3600 * 24));
   const h = Math.floor((seconds % (3600 * 24)) / 3600);
   const m = Math.floor((seconds % 3600) / 60);

--- a/client/src/wrapper.tsx
+++ b/client/src/wrapper.tsx
@@ -193,7 +193,13 @@ export default function Wrapper() {
         </div>
         <Row>
           <Col className="mb-4">
-            <Gauge percentage={ups.ups_load} title={'Current Load'} invert />
+            {ups.ups_load ? (
+              <Gauge percentage={ups.ups_load} title={'Current Load'} invert />
+            ) : (
+              <div style={{ fontSize: `2em` }}>
+                <Kpi text="N/A" description={'Current Load'} />
+              </div>
+            )}
           </Col>
           <Col className="mb-4">
             <Gauge percentage={ups.battery_charge} title={'Battery Charge'} />


### PR DESCRIPTION
My UPS returns `null` for `Current Load` and `-1` for `Battery Runtime`. This PR modifies the display of values for these cases.

Currently, if `Battery Runtime` is `0`, no value is displayed in the field. Instead of applying my fix only to the value `-1`, I applied it to the value `0`, which is converted from the value `-1` when `seconds = Number(seconds);` is called. Of course, this can be modified at will.

Current version of PeaNUT:
![image](https://github.com/Brandawg93/PeaNUT/assets/59953812/99281e8a-f403-40d6-8203-7f7037049578)


After applying the fix:
![image](https://github.com/Brandawg93/PeaNUT/assets/59953812/f50a84ea-9ede-4c88-b3c3-fe53d9ae2759)
