### PR TITLE
re-use existing connection on getData endpoint

### DIFF
--- a/__tests__/unit/server/promise-socket.test.ts
+++ b/__tests__/unit/server/promise-socket.test.ts
@@ -7,6 +7,8 @@ jest.mock('net', () => {
     write: jest.fn(),
     on: jest.fn(),
     removeAllListeners: jest.fn(),
+    listenerCount: jest.fn(),
+    off: jest.fn(),
     end: jest.fn(),
   }
   return { Socket: jest.fn(() => mSocket) }

--- a/src/server/nut.ts
+++ b/src/server/nut.ts
@@ -29,7 +29,7 @@ export class Nut {
     return devices.some((d) => d.name === device)
   }
 
-  private async getCommand(command: string, until?: string, checkCredentials = false): Promise<string> {
+  private async getConnection(checkCredentials = false): Promise<PromiseSocket> {
     const socket = new PromiseSocket()
     try {
       await socket.connect(this.port, this.host)
@@ -39,10 +39,29 @@ export class Nut {
     if (checkCredentials) {
       await this.checkCredentials(socket)
     }
-    await socket.write(command)
-    const data = await socket.readAll(command, until)
+    return socket
+  }
+
+  private async closeConnection(socket: PromiseSocket) {
     await socket.write('LOGOUT')
     await socket.close()
+  }
+
+  private async getCommand(
+    command: string,
+    until?: string,
+    checkCredentials = false,
+    socket?: PromiseSocket
+  ): Promise<string> {
+    // use existing socket if it exists, otherwise establish a new connection
+    const connection = socket || (await this.getConnection(checkCredentials))
+    await connection.write(command)
+    const data = await connection.readAll(command, until)
+    // if we opened a new connection, close it
+    if (!socket) {
+      await connection.write('LOGOUT')
+      await connection.close()
+    }
     if (data.startsWith('ERR')) {
       throw new Error(`Invalid response: ${data}`)
     }
@@ -111,26 +130,28 @@ export class Nut {
   }
 
   public async getData(device = 'UPS'): Promise<VARS> {
+    const socket = await this.getConnection()
     const command = `LIST VAR ${device}`
-    const data = await this.getCommand(command)
+    const data = await this.getCommand(command, undefined, false, socket)
     if (!data.startsWith(`BEGIN ${command}\n`)) {
       console.log('data: ', data)
       throw new Error('Invalid response')
     }
     const vars: VARS = {}
     const lines = data.split('\n').filter((line) => line.startsWith('VAR'))
-    const promises = lines.map(async (line) => {
+    for await (const line of lines) {
       const key = line.split('"')[0].replace(`VAR ${device} `, '').trim()
       const value = line.split('"')[1].trim()
-      const [description, type] = await Promise.all([this.getVarDescription(device, key), this.getType(device, key)])
+      const description = await this.getVarDescription(device, key, socket)
+      const type = await this.getType(device, key, socket)
       if (type.includes('NUMBER') && !isNaN(+value)) {
         const num = +value
         vars[key] = { value: num ? num : value, description }
       } else {
         vars[key] = { value, description }
       }
-    })
-    await Promise.all(promises)
+    }
+    await this.closeConnection(socket)
     return Object.keys(vars)
       .sort()
       .reduce((finalObject: VARS, key) => {
@@ -189,8 +210,8 @@ export class Nut {
     return data.split('"')[1].trim()
   }
 
-  public async getVarDescription(device = 'UPS', variable: string): Promise<string> {
-    const data = await this.getCommand(`GET DESC ${device} ${variable}`, '\n')
+  public async getVarDescription(device = 'UPS', variable: string, socket?: PromiseSocket): Promise<string> {
+    const data = await this.getCommand(`GET DESC ${device} ${variable}`, '\n', false, socket)
     if (!data.startsWith('DESC')) {
       throw new Error('Invalid response')
     }
@@ -215,8 +236,8 @@ export class Nut {
     return ranges
   }
 
-  public async getType(device = 'UPS', variable: string): Promise<string> {
-    const data = await this.getCommand(`GET TYPE ${device} ${variable}`, '\n')
+  public async getType(device = 'UPS', variable: string, socket?: PromiseSocket): Promise<string> {
+    const data = await this.getCommand(`GET TYPE ${device} ${variable}`, '\n', false, socket)
     if (!data.startsWith('TYPE')) {
       throw new Error('Invalid response')
     }

--- a/src/server/promise-socket.ts
+++ b/src/server/promise-socket.ts
@@ -20,7 +20,9 @@ export default class PromiseSocket {
         this.innerSok.on('error', reject)
       }),
       this.setTimeoutPromise(timeout),
-    ])
+    ]).then(() => {
+      this.innerSok.removeAllListeners('error')
+    })
   }
 
   async write(data: string, timeout = TIMEOUT): Promise<void> {
@@ -36,7 +38,9 @@ export default class PromiseSocket {
         this.innerSok.on('error', reject)
       }),
       this.setTimeoutPromise(timeout),
-    ])
+    ]).then(() => {
+      this.innerSok.removeAllListeners('error')
+    })
   }
 
   async readAll(command: string, until: string = `END ${command}`, timeout = TIMEOUT): Promise<string> {
@@ -53,7 +57,12 @@ export default class PromiseSocket {
         this.innerSok.on('end', () => resolve(buf))
       }),
       this.setTimeoutPromise(timeout),
-    ])
+    ]).then((buf) => {
+      this.innerSok.removeAllListeners('data')
+      this.innerSok.removeAllListeners('error')
+      this.innerSok.removeAllListeners('end')
+      return buf
+    })
   }
 
   async close(timeout = TIMEOUT): Promise<void> {


### PR DESCRIPTION
Currently, the getData endpoint establishes a new socket for every individual variable description + type. This results in a lot of TCP handshakes (and DNS queries if using a domain name for the NUT server -- see #126 ). When running PeaNUT in kubernetes, I was frequently experiencing "500 internal server error" messages in the client (as well as in the data API endpoints + InfluxDB writer failing). I never really found a "smoking gun" but maybe something about the flood of connections didn't play nicely with my CNI. I have been able to successfully run PeaNUT + InfluxDB in kubernetes with my changes and it has been running smoothly, it hasn't missed a beat

I re-worked the getData endpoint to establish a single connection and re-use it for each command it executes. Because of this re-work, I also needed to be more careful about cleaning up event listeners on the socket so as not to create a memory leak, so there are a few minor changes there as well.

This is my first time attempting to contribute to PeaNUT, I tried my best to follow the coding style, but happy to make any changes or implement this in a different way if needed. Really like the project, but have been having these connection issues with the 4.x releases when running in kubernetes, so I'm hoping something like this can be implemented!