### PR TITLE
Handle unplugged (or otherwise unreachable) devices more gracefully. …

### DIFF
--- a/__tests__/unit/server/nut.test.ts
+++ b/__tests__/unit/server/nut.test.ts
@@ -1,6 +1,6 @@
 import { Nut } from '@/server/nut'
 import PromiseSocket from '@/server/promise-socket'
-import { DEVICE_UNREACHABLE } from '@/common/constants'
+import { upsStatus } from '@/common/constants'
 
 const listVarUps = `BEGIN LIST VAR ups
 VAR ups battery.charge "100"
@@ -94,13 +94,12 @@ describe('Nut', () => {
 
   it('should detect when a device is unreachable', async () => {
     const nut = new Nut('localhost', 3493)
-    jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue(DEVICE_UNREACHABLE)
+    jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue(upsStatus.DEVICE_UNREACHABLE)
     jest.spyOn(Nut.prototype, 'getType').mockResolvedValue('STRING')
     jest.spyOn(Nut.prototype, 'getVarDescription').mockResolvedValue('test')
 
     const data = await nut.getData('this_ups_cant be reached')
-    expect(data['ups.status'].value).toEqual(DEVICE_UNREACHABLE)
-    expect(data['ups.unreachable'].value).toEqual(1)
+    expect(data['ups.status'].value).toEqual(upsStatus.DEVICE_UNREACHABLE)
   })
 
   it('should work with multiple ups devices on the same server', async () => {

--- a/__tests__/unit/server/nut.test.ts
+++ b/__tests__/unit/server/nut.test.ts
@@ -72,16 +72,6 @@ describe('Nut', () => {
     expect(description).toEqual('Battery charge level')
   })
 
-  it('should work with multiple ups devices on the same server', async () => {
-    const nut = new Nut('localhost', 3493, 'test', 'test')
-    jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue(listVarUps)
-    jest.spyOn(Nut.prototype, 'getType').mockResolvedValue('STRING')
-    jest.spyOn(Nut.prototype, 'getVarDescription').mockResolvedValue('test')
-
-    const data = await nut.getData('ups')
-    expect(data['battery.charge'].value).toEqual('100')
-  })
-
   it('should get devices', async () => {
     const nut = new Nut('localhost', 3493)
     jest

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -108,10 +108,12 @@ export async function getDevices(): Promise<DevicesData> {
             // Skip if we already have this device
             if (deviceMap.has(device.name)) return
 
-            const [data, rwVars, commands] = await Promise.all([
-              nut.getData(device.name),
-              nut.getRWVars(device.name),
-              nut.getCommands(device.name),
+            const data = await nut.getData(device.name)
+            const isReachable = !data['ups.unreachable']?.value
+
+            const [rwVars, commands] = await Promise.all([
+              isReachable ? nut.getRWVars(device.name) : Promise.resolve([]),
+              isReachable ? nut.getCommands(device.name) : Promise.resolve([]),
             ])
 
             deviceMap.set(device.name, {
@@ -148,11 +150,14 @@ export async function getDevice(device: string): Promise<DeviceData> {
       throw new Error('Device not found on this server')
     })
   )
-  const [data, rwVars, commands, description] = await Promise.all([
-    nut.getData(device),
-    nut.getRWVars(device),
-    nut.getCommands(device),
-    nut.getDescription(device),
+
+  const data = await nut.getData(device)
+  const isReachable = !data['ups.unreachable']?.value
+
+  const [rwVars, commands, description] = await Promise.all([
+    isReachable ? nut.getRWVars(device) : Promise.resolve([]),
+    isReachable ? nut.getCommands(device) : Promise.resolve([]),
+    isReachable ? nut.getDescription(device) : Promise.resolve(''),
   ])
   return {
     device: {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -7,6 +7,7 @@ import { DEVICE, server, DeviceData, DevicesData, VarDescription } from '@/commo
 import chokidar from 'chokidar'
 import { AuthError } from 'next-auth'
 import { signIn, signOut } from '@/auth'
+import { upsStatus } from '@/common/constants'
 
 const settingsFile = './config/settings.yml'
 // Cache settings instance
@@ -109,7 +110,7 @@ export async function getDevices(): Promise<DevicesData> {
             if (deviceMap.has(device.name)) return
 
             const data = await nut.getData(device.name)
-            const isReachable = !data['ups.unreachable']?.value
+            const isReachable = data['ups.status']?.value !== upsStatus.DEVICE_UNREACHABLE
 
             const [rwVars, commands] = await Promise.all([
               isReachable ? nut.getRWVars(device.name) : Promise.resolve([]),
@@ -152,7 +153,7 @@ export async function getDevice(device: string): Promise<DeviceData> {
   )
 
   const data = await nut.getData(device)
-  const isReachable = !data['ups.unreachable']?.value
+  const isReachable = data['ups.status']?.value !== upsStatus.DEVICE_UNREACHABLE
 
   const [rwVars, commands, description] = await Promise.all([
     isReachable ? nut.getRWVars(device) : Promise.resolve([]),

--- a/src/client/components/device-wrapper.tsx
+++ b/src/client/components/device-wrapper.tsx
@@ -24,7 +24,7 @@ import Loader from '@/client/components/loader'
 import ChartsContainer from '@/client/components/line-charts/charts-container'
 import Actions from '@/client/components/actions'
 import { LanguageContext } from '@/client/context/language'
-import { DEVICE_UNREACHABLE, upsStatus } from '@/common/constants'
+import { upsStatus } from '@/common/constants'
 import { DeviceData } from '@/common/types'
 import DayNightSwitch from './daynight'
 import LanguageSwitcher from './language-switcher'
@@ -47,7 +47,7 @@ const getStatus = (status: keyof typeof upsStatus) => {
         className='mb-1 inline-block size-6 stroke-[3px] text-red-400'
       />
     )
-  } else if (status.startsWith(DEVICE_UNREACHABLE)) {
+  } else if (status.startsWith(upsStatus.DEVICE_UNREACHABLE)) {
     return <HiXCircle data-testid='xcross-icon' className='mb-1 inline-block size-6 text-red-400' />
   } else {
     return <></>

--- a/src/client/components/device-wrapper.tsx
+++ b/src/client/components/device-wrapper.tsx
@@ -48,7 +48,7 @@ const getStatus = (status: keyof typeof upsStatus) => {
       />
     )
   } else if (status.startsWith(DEVICE_UNREACHABLE)) {
-    return <HiXCircle data-testid='exclamation-icon' className='mb-1 inline-block size-6 text-red-400' />
+    return <HiXCircle data-testid='xcross-icon' className='mb-1 inline-block size-6 text-red-400' />
   } else {
     return <></>
   }

--- a/src/client/components/device-wrapper.tsx
+++ b/src/client/components/device-wrapper.tsx
@@ -7,6 +7,7 @@ import {
   HiOutlineExclamationTriangle,
   HiQuestionMarkCircle,
   HiOutlineExclamationCircle,
+  HiXCircle,
 } from 'react-icons/hi2'
 import { TbSettings } from 'react-icons/tb'
 import { Button } from '@/client/components/ui/button'
@@ -23,7 +24,7 @@ import Loader from '@/client/components/loader'
 import ChartsContainer from '@/client/components/line-charts/charts-container'
 import Actions from '@/client/components/actions'
 import { LanguageContext } from '@/client/context/language'
-import { upsStatus } from '@/common/constants'
+import { DEVICE_UNREACHABLE, upsStatus } from '@/common/constants'
 import { DeviceData } from '@/common/types'
 import DayNightSwitch from './daynight'
 import LanguageSwitcher from './language-switcher'
@@ -46,6 +47,8 @@ const getStatus = (status: keyof typeof upsStatus) => {
         className='mb-1 inline-block size-6 stroke-[3px] text-red-400'
       />
     )
+  } else if (status.startsWith(DEVICE_UNREACHABLE)) {
+    return <HiXCircle data-testid='exclamation-icon' className='mb-1 inline-block size-6 text-red-400' />
   } else {
     return <></>
   }

--- a/src/client/components/wrapper.tsx
+++ b/src/client/components/wrapper.tsx
@@ -20,7 +20,7 @@ import Footer from '@/client/components/footer'
 import Loader from '@/client/components/loader'
 import { LanguageContext } from '@/client/context/language'
 import { DevicesData, DEVICE } from '@/common/types'
-import { DEVICE_UNREACHABLE, upsStatus } from '@/common/constants'
+import { upsStatus } from '@/common/constants'
 import DayNightSwitch from './daynight'
 import LanguageSwitcher from './language-switcher'
 import { Card } from '@/client/components/ui/card'
@@ -50,7 +50,7 @@ const getStatus = (status: string) => {
         className='mb-1 inline-block size-6 stroke-[3px] text-red-400'
       />
     )
-  } else if (status.startsWith(DEVICE_UNREACHABLE)) {
+  } else if (status.startsWith(upsStatus.DEVICE_UNREACHABLE)) {
     return <HiXCircle data-testid='xcross-icon' className='mb-1 inline-block size-6 text-red-400' />
   } else {
     return <></>

--- a/src/client/components/wrapper.tsx
+++ b/src/client/components/wrapper.tsx
@@ -8,6 +8,7 @@ import {
   HiQuestionMarkCircle,
   HiOutlineExclamationCircle,
   HiOutlineInformationCircle,
+  HiXCircle,
 } from 'react-icons/hi2'
 import { TbSettings } from 'react-icons/tb'
 import { Button } from '@/client/components/ui/button'
@@ -19,7 +20,7 @@ import Footer from '@/client/components/footer'
 import Loader from '@/client/components/loader'
 import { LanguageContext } from '@/client/context/language'
 import { DevicesData, DEVICE } from '@/common/types'
-import { upsStatus } from '@/common/constants'
+import { DEVICE_UNREACHABLE, upsStatus } from '@/common/constants'
 import DayNightSwitch from './daynight'
 import LanguageSwitcher from './language-switcher'
 import { Card } from '@/client/components/ui/card'
@@ -49,6 +50,8 @@ const getStatus = (status: string) => {
         className='mb-1 inline-block size-6 stroke-[3px] text-red-400'
       />
     )
+  } else if (status.startsWith(DEVICE_UNREACHABLE)) {
+    return <HiXCircle data-testid='exclamation-icon' className='mb-1 inline-block size-6 text-red-400' />
   } else {
     return <></>
   }

--- a/src/client/components/wrapper.tsx
+++ b/src/client/components/wrapper.tsx
@@ -51,7 +51,7 @@ const getStatus = (status: string) => {
       />
     )
   } else if (status.startsWith(DEVICE_UNREACHABLE)) {
-    return <HiXCircle data-testid='exclamation-icon' className='mb-1 inline-block size-6 text-red-400' />
+    return <HiXCircle data-testid='xcross-icon' className='mb-1 inline-block size-6 text-red-400' />
   } else {
     return <></>
   }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -77,5 +77,3 @@ export const SUPPORTED_COMMANDS = {
 }
 
 export const DEFAULT_INFLUX_INTERVAL = 10
-
-export const DEVICE_UNREACHABLE = 'DEVICE_UNREACHABLE'

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -15,6 +15,7 @@ export const upsStatus = {
   BOOST: 'Boosting Voltage',
   FSD: 'Forced Shutdown',
   ALARM: 'Alarm',
+  DEVICE_UNREACHABLE: 'Device Unreachable',
 }
 
 const COMMAND_BEEPER_DISABLE = 'beeper.disable'
@@ -76,3 +77,5 @@ export const SUPPORTED_COMMANDS = {
 }
 
 export const DEFAULT_INFLUX_INTERVAL = 10
+
+export const DEVICE_UNREACHABLE = 'DEVICE_UNREACHABLE'

--- a/src/server/nut.ts
+++ b/src/server/nut.ts
@@ -1,4 +1,4 @@
-import { DEVICE_UNREACHABLE } from '@/common/constants'
+import { upsStatus } from '@/common/constants'
 import { DEVICE, VARS } from '@/common/types'
 import PromiseSocket from '@/server/promise-socket'
 
@@ -71,7 +71,7 @@ export class Nut {
     await connection.write(command)
     const data = await connection.readAll(command, until).catch((error) => {
       if (command.startsWith('LIST VAR')) {
-        return DEVICE_UNREACHABLE
+        return upsStatus.DEVICE_UNREACHABLE
       }
       throw new Error(`Error response: ${error}`)
     })
@@ -171,11 +171,10 @@ export class Nut {
     const socket = await this.getConnection()
     const command = `LIST VAR ${device}`
     const data = await this.getCommand(command, undefined, false, socket)
-    if (data == DEVICE_UNREACHABLE) {
+    if (data == upsStatus.DEVICE_UNREACHABLE) {
       return {
-        'ups.device_name': { value: device, description: 'Device name' },
-        'ups.status': { value: DEVICE_UNREACHABLE, description: 'UPS status' },
-        'ups.unreachable': { value: 1, description: 'UPS is unreachable' },
+        'ups.device_name': { value: device },
+        'ups.status': { value: upsStatus.DEVICE_UNREACHABLE },
       }
     }
     if (!data.startsWith(`BEGIN ${command}\n`)) {
@@ -197,7 +196,6 @@ export class Nut {
       }
     }
     await this.closeConnection(socket)
-    vars['ups.device_name'] = { value: device, description: 'Device Name on NUT config' }
     return Object.keys(vars)
       .sort((a, b) => a.localeCompare(b))
       .reduce((finalObject: VARS, key) => {


### PR DESCRIPTION
…Also add 'ups.device_name' to vars

Sorry for the long commit comment

This commit will show unreachable devices in the UI as well. I think this is the more correct behaviour because if a device is defined in ups.conf but is not reachable, some API endpoints just return 500 and the UI doesn't show any error or other information at all. I found out the bad way when I disconnected one of my UPS today in the morning and came back home to an empty period in my Grafana dashboard (the prometheus API endpoint started crashing right after I disconnected my UPS)

There might be a better way to handle this behaviour since my changes only mimic the NUT API and there is still a long timeout (10 seconds) if we hit this edge case, this might be avoidable but as far as I understand, this is caused upstream by the NUT server, so maybe its out of scope for this repo.

This might make #212 irrelevant

Please let me know if there are any comments or corrections on this PR, thanks! And enjoy your weekend