### PR TITLE
Fix health check due to missing wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,8 @@ COPY --link --chown=1000:1000 --from=build /app/.next/static ./.next/static
 # Copy and set up entrypoint script
 COPY --link --chown=1000:1000 entrypoint.sh /entrypoint.sh
 
-# Install nodejs and tini
-RUN apk add --no-cache libstdc++ nodejs tini && chmod +x /entrypoint.sh
+# Install nodejs, tini, and wget for healthcheck
+RUN apk add --no-cache libstdc++ nodejs tini wget && chmod +x /entrypoint.sh
 
 # Set environment variables
 ENV CI=true


### PR DESCRIPTION
Add `wget` to the Dockerfile's runner stage to fix the failing `HEALTHCHECK`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ad486cc-ddb0-4981-8aee-ef47d56b3c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ad486cc-ddb0-4981-8aee-ef47d56b3c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

