### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto'
 import NextAuth from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import { authConfig } from './auth.config'
@@ -12,7 +13,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         if (parsedCredentials.success) {
           const { username, password } = parsedCredentials.data
-          if (username === process.env.WEB_USERNAME && password === process.env.WEB_PASSWORD) {
+          if (username === process.env.WEB_USERNAME && process.env.WEB_PASSWORD && (() => { try { return timingSafeEqual(Buffer.from(password), Buffer.from(process.env.WEB_PASSWORD)) } catch { return false } })()) {
             return { name: username }
           }
         }


### PR DESCRIPTION
## Summary
Fixes #403 — replaces timing-vulnerable `===` comparison with constant-time `timingSafeEqual`.

## Changes
- Replace direct string comparison with constant-time comparison for web password
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`crypto`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*