### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,14 @@
+import { timingSafeEqual } from 'crypto'
 import NextAuth from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
+
+function safeEqual(a: string, b: string): boolean {
+  try {
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+  } catch {
+    return false
+  }
+}
 import { authConfig } from './auth.config'
 import { z } from 'zod'
 
@@ -12,7 +21,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         if (parsedCredentials.success) {
           const { username, password } = parsedCredentials.data
-          if (username === process.env.WEB_USERNAME && password === process.env.WEB_PASSWORD) {
+          if (username === process.env.WEB_USERNAME && process.env.WEB_PASSWORD && safeEqual(password, process.env.WEB_PASSWORD)) {
             return { name: username }
           }
         }


### PR DESCRIPTION
## Summary
Fixes #403 — replaces timing-vulnerable `===` comparison with constant-time `timingSafeEqual`.

## Changes
- Replace direct string comparison with constant-time comparison for web password
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`crypto`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*