### PR TITLE
Fix WS terminal auth behind SSL-terminating proxies

### DIFF
--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -33,9 +33,12 @@ export async function UPGRADE(
   request: import('next/server').NextRequest
 ) {
   if (process.env.WEB_USERNAME && process.env.WEB_PASSWORD) {
+    const forwardedProto = request.headers.get('x-forwarded-proto')
+    const secureCookie = forwardedProto === 'https' || request.nextUrl.protocol === 'https:'
     const token = await getToken({
       req: request,
       secret: process.env.AUTH_SECRET,
+      secureCookie,
     })
 
     if (!token) {

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -34,7 +34,8 @@ export async function UPGRADE(
 ) {
   if (process.env.WEB_USERNAME && process.env.WEB_PASSWORD) {
     const forwardedProto = request.headers.get('x-forwarded-proto')
-    const secureCookie = forwardedProto === 'https' || request.nextUrl.protocol === 'https:'
+    const normalizedForwardedProto = (forwardedProto ?? '').split(',')[0].trim().toLowerCase()
+    const secureCookie = normalizedForwardedProto === 'https' || request.nextUrl.protocol === 'https:'
     const token = await getToken({
       req: request,
       secret: process.env.AUTH_SECRET,


### PR DESCRIPTION
## Summary
- WS terminal in settings was failing with `{"type":"error","message":"Unauthorized"}` for users running PeaNUT behind a reverse proxy that terminates SSL (e.g. Cloudflare).
- Root cause: when the browser is on HTTPS, NextAuth issues the session cookie with the `__Secure-` prefix. The WS upgrade handler called `getToken()` without `secureCookie`, which defaults to `false` and looks for the non-prefixed `authjs.session-token`. The proxy hides the original protocol from `next-ws`, so the request reaches Node as HTTP and the cookie name mismatch was never detectable from the socket alone.
- Fix: detect the original protocol from `x-forwarded-proto` (falling back to `request.nextUrl.protocol`) and pass `secureCookie` through to `getToken` so it looks for the right cookie name and uses the matching salt for decryption.

This bug was latent — the `getToken` call has been there since #354 — but only surfaced for users with `WEB_USERNAME`/`WEB_PASSWORD` env vars set who were also behind an SSL-terminating proxy.

## Test plan
- [x] Verified terminal connects and works behind Cloudflare with HTTPS + `WEB_USERNAME`/`WEB_PASSWORD` set
- [ ] Sanity check terminal still works for direct HTTP (no proxy) and direct HTTPS (no proxy)
- [ ] Sanity check unauthorized path still fires when no/invalid session cookie is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)