### PR TITLE
Parallelize metrics fetch and consolidate Influx points

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v6
       with:
-        version: latest
+        version: 10
 
     - uses: actions/setup-node@v6.4.0
       with:

--- a/__tests__/unit/server/influxdb.test.ts
+++ b/__tests__/unit/server/influxdb.test.ts
@@ -98,7 +98,7 @@ describe('InfluxWriter', () => {
       const writePointMock = jest.spyOn(influxWriter['writeApi'], 'writePoint')
       influxWriter.writePoint(device)
 
-      expect(writePointMock).toHaveBeenCalledTimes(3)
+      expect(writePointMock).toHaveBeenCalledTimes(1)
       expect(Point).toHaveBeenCalledWith('test-device')
       expect(mockPoint.tag).toHaveBeenCalledWith('description', 'test description')
       expect(mockPoint.tag).toHaveBeenCalledWith('server', 'localhost:3493')
@@ -122,7 +122,7 @@ describe('InfluxWriter', () => {
       const writePointMock = jest.spyOn(influxWriter['writeApi'], 'writePoint')
       influxWriter.writePoint(device)
 
-      expect(writePointMock).toHaveBeenCalledTimes(3)
+      expect(writePointMock).toHaveBeenCalledTimes(1)
       expect(Point).toHaveBeenCalledWith('test-device')
       expect(mockPoint.tag).toHaveBeenCalledWith('description', 'test description')
       expect(mockPoint.stringField).toHaveBeenCalledWith('status', 'Online')
@@ -146,7 +146,7 @@ describe('InfluxWriter', () => {
       const writePointMock = jest.spyOn(influxWriter['writeApi'], 'writePoint')
       influxWriter.writePoint(device)
 
-      expect(writePointMock).toHaveBeenCalledTimes(4)
+      expect(writePointMock).toHaveBeenCalledTimes(1)
       expect(mockPoint.floatField).toHaveBeenCalledWith('temperature', 25.5)
       expect(mockPoint.floatField).toHaveBeenCalledWith('voltage', 120.0)
       expect(mockPoint.stringField).toHaveBeenCalledWith('status', 'Online')
@@ -240,10 +240,7 @@ describe('InfluxWriter', () => {
       influxWriter.writePoint(device)
 
       expect(writePointMock).toHaveBeenCalled()
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to write field temperature for device test-device:',
-        expect.any(Error)
-      )
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to write point for device test-device:', expect.any(Error))
       consoleErrorSpy.mockRestore()
     })
 
@@ -264,9 +261,9 @@ describe('InfluxWriter', () => {
 
       influxWriter.writePoint(device)
 
-      // Should attempt to write all fields and log errors for each
-      expect(writePointMock).toHaveBeenCalledTimes(3)
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(3)
+      // Single consolidated point write — one error on failure
+      expect(writePointMock).toHaveBeenCalledTimes(1)
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
       consoleErrorSpy.mockRestore()
     })
 
@@ -298,9 +295,11 @@ describe('InfluxWriter', () => {
       const writePointMock = jest.spyOn(influxWriter['writeApi'], 'writePoint')
       influxWriter.writePoint(device)
 
-      // Should only write the valid numeric field
+      // Should write a single consolidated point containing only the valid numeric field
       expect(writePointMock).toHaveBeenCalledTimes(1)
       expect(mockPoint.floatField).toHaveBeenCalledWith('valid', 25.5)
+      expect(mockPoint.floatField).toHaveBeenCalledTimes(1)
+      expect(mockPoint.stringField).not.toHaveBeenCalled()
       consoleErrorSpy.mockRestore()
     })
 
@@ -327,7 +326,7 @@ describe('InfluxWriter', () => {
       const writePointMock = jest.spyOn(influxWriter['writeApi'], 'writePoint')
       influxWriter.writePoint(device)
 
-      expect(writePointMock).toHaveBeenCalledTimes(2)
+      expect(writePointMock).toHaveBeenCalledTimes(1)
       expect(mockPoint.floatField).toHaveBeenCalledWith('temperature', 25.5)
       expect(mockPoint.stringField).toHaveBeenCalledWith('status', 'Online')
       consoleErrorSpy.mockRestore()

--- a/src/app/api/v1/metrics/route.ts
+++ b/src/app/api/v1/metrics/route.ts
@@ -30,6 +30,30 @@ function isNumeric(value: string | number): boolean {
   return !isNaN(Number(value))
 }
 
+// Per-instance concurrency cap for getData() calls. Aligned with the NUT
+// connection pool's idle-retention size so a Prometheus scrape doesn't burst
+// far past what the pool can absorb (pool only caps idle sockets; without
+// this cap, N devices means N simultaneous TCP connections per scrape).
+const PER_INSTANCE_CONCURRENCY = 3
+
+async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<Array<R>> {
+  const results: Array<R> = new Array(items.length)
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++
+      if (i >= items.length) return
+      results[i] = await fn(items[i], i)
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function GET(request: NextRequest) {
   const nutInstances = await getNutInstances()
@@ -40,25 +64,23 @@ export async function GET(request: NextRequest) {
       const devices = await nut.getDevices()
       const serverInfo = `${nut.getHost()}:${nut.getPort()}`
 
-      const perDeviceMetrics = await Promise.all(
-        devices.map(async (device) => {
-          const data = await nut.getData(device.name)
-          const lines: string[] = []
+      const perDeviceMetrics = await mapWithConcurrency(devices, PER_INSTANCE_CONCURRENCY, async (device) => {
+        const data = await nut.getData(device.name)
+        const lines: string[] = []
 
-          for (const [key, value] of Object.entries(data)) {
-            if (isNumeric(value.value)) {
-              const metricName = toMetricName(key)
-              const metricValue = Number(value.value)
-              const metricDescription = value.description ?? 'N/A'
-              const labels = `ups="${device.name}",server="${serverInfo}"`
-              lines.push(`# HELP ${metricName} ${metricDescription}`)
-              lines.push(`# TYPE ${metricName} gauge`)
-              lines.push(`${metricName}{${labels}} ${metricValue}`)
-            }
+        for (const [key, value] of Object.entries(data)) {
+          if (isNumeric(value.value)) {
+            const metricName = toMetricName(key)
+            const metricValue = Number(value.value)
+            const metricDescription = value.description ?? 'N/A'
+            const labels = `ups="${device.name}",server="${serverInfo}"`
+            lines.push(`# HELP ${metricName} ${metricDescription}`)
+            lines.push(`# TYPE ${metricName} gauge`)
+            lines.push(`${metricName}{${labels}} ${metricValue}`)
           }
-          return lines
-        })
-      )
+        }
+        return lines
+      })
       return perDeviceMetrics.flat()
     })
   )

--- a/src/app/api/v1/metrics/route.ts
+++ b/src/app/api/v1/metrics/route.ts
@@ -35,29 +35,34 @@ export async function GET(request: NextRequest) {
   const nutInstances = await getNutInstances()
   const prometheusMetrics: string[] = []
 
-  for (const nut of nutInstances) {
-    const devices = await nut.getDevices()
-    const serverInfo = `${nut.getHost()}:${nut.getPort()}`
+  const perInstanceMetrics = await Promise.all(
+    nutInstances.map(async (nut) => {
+      const devices = await nut.getDevices()
+      const serverInfo = `${nut.getHost()}:${nut.getPort()}`
 
-    for (const device of devices) {
-      const data = await nut.getData(device.name)
+      const perDeviceMetrics = await Promise.all(
+        devices.map(async (device) => {
+          const data = await nut.getData(device.name)
+          const lines: string[] = []
 
-      for (const [key, value] of Object.entries(data)) {
-        // Only process numeric values
-        if (isNumeric(value.value)) {
-          const metricName = toMetricName(key)
-          const metricValue = Number(value.value)
-          const metricDescription = value.description ?? 'N/A'
-
-          // Add labels for the device including server for multi-server disambiguation
-          const labels = `ups="${device.name}",server="${serverInfo}"`
-          prometheusMetrics.push(`# HELP ${metricName} ${metricDescription}`)
-          prometheusMetrics.push(`# TYPE ${metricName} gauge`)
-          prometheusMetrics.push(`${metricName}{${labels}} ${metricValue}`)
-        }
-      }
-    }
-  }
+          for (const [key, value] of Object.entries(data)) {
+            if (isNumeric(value.value)) {
+              const metricName = toMetricName(key)
+              const metricValue = Number(value.value)
+              const metricDescription = value.description ?? 'N/A'
+              const labels = `ups="${device.name}",server="${serverInfo}"`
+              lines.push(`# HELP ${metricName} ${metricDescription}`)
+              lines.push(`# TYPE ${metricName} gauge`)
+              lines.push(`${metricName}{${labels}} ${metricValue}`)
+            }
+          }
+          return lines
+        })
+      )
+      return perDeviceMetrics.flat()
+    })
+  )
+  prometheusMetrics.push(...perInstanceMetrics.flat())
 
   // Return metrics with proper content type
   return new NextResponse(prometheusMetrics.join('\n'), {

--- a/src/app/api/v1/metrics/route.ts
+++ b/src/app/api/v1/metrics/route.ts
@@ -74,9 +74,11 @@ export async function GET(request: NextRequest) {
             const metricValue = Number(value.value)
             const metricDescription = value.description ?? 'N/A'
             const labels = `ups="${device.name}",server="${serverInfo}"`
-            lines.push(`# HELP ${metricName} ${metricDescription}`)
-            lines.push(`# TYPE ${metricName} gauge`)
-            lines.push(`${metricName}{${labels}} ${metricValue}`)
+            lines.push(
+              `# HELP ${metricName} ${metricDescription}`,
+              `# TYPE ${metricName} gauge`,
+              `${metricName}{${labels}} ${metricValue}`
+            )
           }
         }
         return lines

--- a/src/server/influxdb.ts
+++ b/src/server/influxdb.ts
@@ -46,41 +46,36 @@ export default class InfluxWriter {
     let floatFieldCount = 0
     let stringFieldCount = 0
 
-    for (const key of Object.keys(device.vars)) {
-      const variable = device.vars[key]
+    const point = new Point(device.name).tag('description', device.description).tag('server', device.server) // Server tag for multi-server disambiguation
+
+    for (const [key, variable] of Object.entries(device.vars)) {
       const value = variable.value
-
-      if (typeof value !== 'number' && typeof value !== 'string') {
-        continue
-      }
-
-      const point = new Point(device.name).tag('description', device.description).tag('server', device.server) // Server tag for multi-server disambiguation
 
       if (typeof value === 'number') {
         point.floatField(key, value)
-      } else {
+        floatFieldCount++
+      } else if (typeof value === 'string') {
         point.stringField(key, value)
+        stringFieldCount++
       }
+    }
 
-      if (timestamp) {
-        point.timestamp(timestamp)
-      }
+    if (floatFieldCount === 0 && stringFieldCount === 0) {
+      return
+    }
 
-      try {
-        this.writeApi.writePoint(point)
-        if (typeof value === 'number') {
-          floatFieldCount++
-        } else {
-          stringFieldCount++
-        }
-      } catch (e) {
-        this.debug.error('Failed to write field', {
-          device: device.name,
-          field: key,
-          error: e instanceof Error ? e.message : String(e),
-        })
-        console.error(`Failed to write field ${key} for device ${device.name}:`, e)
-      }
+    if (timestamp) {
+      point.timestamp(timestamp)
+    }
+
+    try {
+      this.writeApi.writePoint(point)
+    } catch (e) {
+      this.debug.error('Failed to write point', {
+        device: device.name,
+        error: e instanceof Error ? e.message : String(e),
+      })
+      console.error(`Failed to write point for device ${device.name}:`, e)
     }
 
     this.debug.debug('Device data write completed', {


### PR DESCRIPTION
## Summary
- Parallelize NUT instance/device fetches in the v1 Prometheus metrics route, matching the pattern already used by the v1 devices route. Sequential `await` in nested `for...of` loops added unnecessary linear latency.
- Consolidate per-device InfluxDB writes into a single `Point` carrying all numeric/string fields. The previous code created N single-field points per device, producing N line-protocol records and N `writeApi.writePoint` calls per device write.
- Minor: switched a `for (const key of Object.keys(...))` loop to `Object.entries()` in `influxdb.ts` for clarity.

Each of these came out of an AI code-review pass. Two suggestions in the same review were rejected as incorrect (a "parallelize var description+type" suggestion that would have multiplexed unrelated commands onto a single NUT socket, and a "use forEach instead of for...of" suggestion that was pure churn) and are not included here.

## Test plan
- [x] `npx jest` — 413 passed, 1 skipped
- [x] `npm run type-check` (precheck hook) passes
- [x] `eslint` (lint-staged) passes
- [ ] Manual: hit `/api/v1/metrics` against a multi-instance, multi-device NUT setup and confirm output matches the previous serial implementation (ordering preserved)
- [ ] Manual: confirm InfluxDB receives one point per device with all fields, instead of N points

🤖 Generated with [Claude Code](https://claude.com/claude-code)