### PR TITLE
Raise unit test coverage and enforce a CI floor

### DIFF
--- a/.github/workflows/npmbuild.yml
+++ b/.github/workflows/npmbuild.yml
@@ -51,8 +51,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      - name: Run jest
-        run: pnpm test
+      - name: Run jest with coverage
+        run: pnpm run test:coverage
 
   e2e:
     name: E2E tests

--- a/__tests__/unit/app/actions.test.ts
+++ b/__tests__/unit/app/actions.test.ts
@@ -259,6 +259,92 @@ describe('actions', () => {
     expect(data.devices![1].server).toBe('Server2')
   })
 
+  describe('error and branch paths', () => {
+    beforeEach(() => {
+      // Prior tests overwrite the NUT_SERVERS mock; re-apply the canonical one
+      // so composite-ID lookups can find the test host.
+      ;(YamlSettings.prototype.get as jest.Mock).mockImplementation((key: keyof SettingsType) => {
+        const settings = {
+          NUT_SERVERS: [
+            { HOST: TEST_HOSTNAME, PORT: TEST_PORT, USERNAME: TEST_USERNAME, PASSWORD: undefined, DISABLED: false },
+          ],
+        }
+        return settings[key as keyof typeof settings]
+      })
+    })
+
+    it('testConnection invokes checkCredentials when credentials provided', async () => {
+      ;(Nut.prototype.checkCredentials as jest.Mock).mockClear()
+      await testConnection(TEST_HOSTNAME, TEST_PORT, TEST_USERNAME, TEST_PASSWORD)
+      expect(Nut.prototype.checkCredentials).toHaveBeenCalled()
+    })
+
+    it('testConnection wraps inner errors', async () => {
+      ;(Nut.prototype.testConnection as jest.Mock).mockRejectedValueOnce(new Error('refused'))
+      await expect(testConnection(TEST_HOSTNAME, TEST_PORT)).rejects.toThrow('refused')
+    })
+
+    it('saveVar returns error message when underlying setVar fails', async () => {
+      ;(Nut.prototype.setVar as jest.Mock).mockRejectedValueOnce(new Error('not writable'))
+      const result = await saveVar('foo', 'battery.charge', '50')
+      expect(result.error).toBe('not writable')
+    })
+
+    it('saveVar targets a specific server for composite device IDs', async () => {
+      const setVarSpy = (Nut.prototype.setVar as jest.Mock).mockClear()
+      const result = await saveVar(`${TEST_HOSTNAME}~${TEST_PORT}~foo`, 'battery.charge', '50')
+      expect(result.error).toBeUndefined()
+      expect(setVarSpy).toHaveBeenCalled()
+    })
+
+    it('saveVar reports "Device not found" for unknown composite IDs', async () => {
+      ;(Nut.prototype.deviceExists as jest.Mock).mockResolvedValueOnce(false)
+      const result = await saveVar(`${TEST_HOSTNAME}~${TEST_PORT}~ghost`, 'battery.charge', '50')
+      expect(result.error).toBe('Device not found')
+    })
+
+    it('runCommand reports "Device not found" for unknown composite IDs', async () => {
+      ;(Nut.prototype.deviceExists as jest.Mock).mockResolvedValueOnce(false)
+      const result = await runCommand(`${TEST_HOSTNAME}~${TEST_PORT}~ghost`, 'test.battery.start')
+      expect(result.error).toBe('Device not found')
+    })
+
+    it('runCommand targets a specific server for composite device IDs', async () => {
+      const runSpy = (Nut.prototype.runCommand as jest.Mock).mockClear()
+      ;(Nut.prototype.deviceExists as jest.Mock).mockResolvedValueOnce(true)
+      const result = await runCommand(`${TEST_HOSTNAME}~${TEST_PORT}~foo`, 'test.battery.start')
+      expect(result.error).toBeUndefined()
+      expect(runSpy).toHaveBeenCalledWith('test.battery.start', 'foo')
+    })
+
+    it('getAllCommands collects commands from composite ID path', async () => {
+      ;(Nut.prototype.getCommands as jest.Mock).mockResolvedValueOnce(['shutdown.reboot'])
+      ;(Nut.prototype.deviceExists as jest.Mock).mockResolvedValueOnce(true)
+      const commands = await getAllCommands(`${TEST_HOSTNAME}~${TEST_PORT}~foo`)
+      expect(commands).toEqual(['shutdown.reboot'])
+    })
+
+    it('getAllCommands returns [] when the underlying call throws', async () => {
+      ;(Nut.prototype.getCommands as jest.Mock).mockRejectedValueOnce(new Error('boom'))
+      const commands = await getAllCommands('foo')
+      expect(commands).toEqual([])
+    })
+
+    it('getAllVarDescriptions returns an error message when the lookup throws', async () => {
+      ;(Nut.prototype.deviceExists as jest.Mock).mockResolvedValueOnce(false)
+      const result = await getAllVarDescriptions(`${TEST_HOSTNAME}~${TEST_PORT}~ghost`, ['battery.charge'])
+      expect(result.error).toBeDefined()
+    })
+
+    it('checkSettings returns false when the settings lookup throws', async () => {
+      ;(YamlSettings.prototype.get as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('disk gone')
+      })
+      const result = await checkSettings()
+      expect(result).toBe(false)
+    })
+  })
+
   describe('authenticate', () => {
     beforeEach(() => {
       jest.clearAllMocks()

--- a/__tests__/unit/auth.test.ts
+++ b/__tests__/unit/auth.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Verifies the Credentials provider `authorize` callback wired up in src/auth.ts.
+ *
+ * The next-auth mock at __tests__/__mocks__/next-auth.ts (applied via the
+ * jest config moduleNameMapper) replaces the default export for both
+ * `next-auth` and `next-auth/providers/credentials` with a single jest.fn.
+ * That means when src/auth.ts evaluates:
+ *
+ *   NextAuth({ providers: [Credentials({ authorize })] })
+ *
+ * both inner calls are recorded on the same mock. The first recorded call
+ * (index 0) corresponds to `Credentials({ authorize })`, so we can pull the
+ * authorize callback off it and drive it directly with crafted credentials.
+ */
+
+const mockGetAuthUser = jest.fn()
+const mockVerifyPassword = jest.fn()
+
+jest.mock('@/server/auth-storage', () => ({
+  authStorage: {
+    getAuthUser: mockGetAuthUser,
+    verifyPassword: mockVerifyPassword,
+  },
+}))
+
+import { TEST_USERNAME, TEST_PASSWORD } from '../utils/test-constants'
+import mockedNextAuth from 'next-auth'
+
+describe('src/auth.ts Credentials authorize', () => {
+  let authorize: (credentials: unknown) => Promise<unknown>
+
+  beforeAll(async () => {
+    // Importing the module triggers the NextAuth and Credentials calls.
+    await import('@/auth')
+    const calls = (mockedNextAuth as unknown as jest.Mock).mock.calls
+    // First call records the Credentials({ authorize }) config object.
+    authorize = calls[0][0].authorize
+  })
+
+  beforeEach(() => {
+    mockGetAuthUser.mockReset()
+    mockVerifyPassword.mockReset()
+  })
+
+  test('returns null when credentials are missing required fields', async () => {
+    const result = await authorize({})
+    expect(result).toBeNull()
+    expect(mockGetAuthUser).not.toHaveBeenCalled()
+  })
+
+  test('returns null when password is too short to pass zod schema', async () => {
+    const result = await authorize({ username: TEST_USERNAME, password: 'abc' })
+    expect(result).toBeNull()
+    expect(mockGetAuthUser).not.toHaveBeenCalled()
+  })
+
+  test('returns null when no auth user is configured', async () => {
+    mockGetAuthUser.mockReturnValue(null)
+    const result = await authorize({ username: TEST_USERNAME, password: TEST_PASSWORD })
+    expect(result).toBeNull()
+    expect(mockVerifyPassword).not.toHaveBeenCalled()
+  })
+
+  test('returns null when username does not match stored user', async () => {
+    mockGetAuthUser.mockReturnValue({ username: 'other-user' })
+    const result = await authorize({ username: TEST_USERNAME, password: TEST_PASSWORD })
+    expect(result).toBeNull()
+    expect(mockVerifyPassword).not.toHaveBeenCalled()
+  })
+
+  test('returns null when verifyPassword resolves false', async () => {
+    mockGetAuthUser.mockReturnValue({ username: TEST_USERNAME })
+    mockVerifyPassword.mockResolvedValue(false)
+    const result = await authorize({ username: TEST_USERNAME, password: TEST_PASSWORD })
+    expect(result).toBeNull()
+    expect(mockVerifyPassword).toHaveBeenCalledWith(TEST_PASSWORD)
+  })
+
+  test('returns { name } on successful authentication', async () => {
+    mockGetAuthUser.mockReturnValue({ username: TEST_USERNAME })
+    mockVerifyPassword.mockResolvedValue(true)
+    const result = await authorize({ username: TEST_USERNAME, password: TEST_PASSWORD })
+    expect(result).toEqual({ name: TEST_USERNAME })
+  })
+})

--- a/__tests__/unit/client/components/actions.test.tsx
+++ b/__tests__/unit/client/components/actions.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import Actions from '@/client/components/actions'
+import { renderWithProviders } from '../../../utils/test-utils'
+
+// sonner emits portals to document.body and uses ResizeObserver etc. Stub it.
+jest.mock('sonner', () => ({
+  Toaster: () => null,
+  toast: { success: jest.fn(), error: jest.fn() },
+}))
+
+describe('Actions menu', () => {
+  it('renders nothing when the device supports none of the known commands', () => {
+    renderWithProviders(<Actions device='ups' commands={['some.unrelated.cmd']} runCommandAction={jest.fn()} />)
+    // No buttons should be rendered when the menu suppresses itself.
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('renders the action trigger when a supported test command is present', () => {
+    renderWithProviders(<Actions device='ups' commands={['test.battery.start.quick']} runCommandAction={jest.fn()} />)
+    // The DropdownMenuTrigger is a button; we just need to confirm the component
+    // mounted rather than collapsing to null.
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+  })
+
+  it('renders when shutdown commands are supported', () => {
+    renderWithProviders(
+      <Actions device='ups' commands={['shutdown.return', 'shutdown.stayoff']} runCommandAction={jest.fn()} />
+    )
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+  })
+
+  it('renders when beeper commands are supported and vars indicate enabled state', () => {
+    renderWithProviders(
+      <Actions
+        device='ups'
+        commands={['beeper.enable', 'beeper.disable', 'beeper.mute']}
+        runCommandAction={jest.fn()}
+        vars={{ 'ups.beeper.status': { value: 'enabled' } }}
+      />
+    )
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+  })
+
+  it('handles vars indicating beeper is disabled', () => {
+    renderWithProviders(
+      <Actions
+        device='ups'
+        commands={['beeper.enable', 'beeper.disable']}
+        runCommandAction={jest.fn()}
+        vars={{ 'beeper.status': { value: 'disabled' } }}
+      />
+    )
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+  })
+
+  it('renders when vars have no beeper signal', () => {
+    renderWithProviders(
+      <Actions
+        device='ups'
+        commands={['beeper.enable']}
+        runCommandAction={jest.fn()}
+        vars={{ 'battery.charge': { value: '100' } }}
+      />
+    )
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+  })
+})

--- a/__tests__/unit/client/components/refresh.test.tsx
+++ b/__tests__/unit/client/components/refresh.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { screen, fireEvent, act } from '@testing-library/react'
+import Refresh from '@/client/components/refresh'
+import { renderWithProviders } from '../../../utils/test-utils'
+
+describe('Refresh', () => {
+  const baseProps = {
+    onClick: jest.fn(),
+    onRefreshChange: jest.fn(),
+    refreshInterval: 0,
+    disabled: false,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('renders both buttons', () => {
+    renderWithProviders(<Refresh {...baseProps} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(2)
+  })
+
+  it('invokes onClick when the refresh button is pressed', () => {
+    const onClick = jest.fn()
+    renderWithProviders(<Refresh {...baseProps} onClick={onClick} />)
+
+    const [refreshButton] = screen.getAllByRole('button')
+    fireEvent.click(refreshButton)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears spin effect on animation end', () => {
+    renderWithProviders(<Refresh {...baseProps} />)
+    const [refreshButton] = screen.getAllByRole('button')
+    fireEvent.click(refreshButton)
+    fireEvent.animationEnd(refreshButton)
+    // No exception → branch covered
+    expect(refreshButton).toBeInTheDocument()
+  })
+
+  it('disables the refresh button when disabled prop is true', () => {
+    renderWithProviders(<Refresh {...baseProps} disabled />)
+    const [refreshButton] = screen.getAllByRole('button')
+    expect(refreshButton).toBeDisabled()
+  })
+
+  const openDropdown = async () => {
+    const [, dropdownTrigger] = screen.getAllByRole('button')
+    await act(async () => {
+      fireEvent.pointerDown(dropdownTrigger, { button: 0, ctrlKey: false })
+      fireEvent.mouseDown(dropdownTrigger, { button: 0 })
+      fireEvent.click(dropdownTrigger)
+    })
+  }
+
+  it('selects an interval, writes localStorage, and notifies parent', async () => {
+    const onRefreshChange = jest.fn()
+    renderWithProviders(<Refresh {...baseProps} onRefreshChange={onRefreshChange} />)
+
+    await openDropdown()
+
+    const item = await screen.findByText('5s')
+    await act(async () => {
+      fireEvent.click(item)
+    })
+
+    expect(onRefreshChange).toHaveBeenCalledWith(5)
+    expect(localStorage.getItem('refreshInterval')).toBe('5')
+  })
+
+  it('renders "off" for the 0 option', async () => {
+    renderWithProviders(<Refresh {...baseProps} />)
+    await openDropdown()
+    expect(await screen.findByText('off')).toBeInTheDocument()
+  })
+
+  it('marks the active interval option', async () => {
+    renderWithProviders(<Refresh {...baseProps} refreshInterval={10} />)
+    await openDropdown()
+    const active = await screen.findByText('10s')
+    expect(active.className).toContain('bg-secondary-highlight!')
+  })
+})

--- a/__tests__/unit/client/components/wrapper.test.tsx
+++ b/__tests__/unit/client/components/wrapper.test.tsx
@@ -163,6 +163,45 @@ describe('Wrapper Component', () => {
     expect(icon).toBeInTheDocument()
   })
 
+  it('invokes the user-provided getDevicesAction via the useQuery queryFn', async () => {
+    const getDevicesAction = jest.fn().mockResolvedValue(mockDevicesData)
+    let capturedQueryFn: (() => Promise<unknown>) | undefined
+    ;(useQuery as jest.Mock).mockImplementation((config: { queryFn: () => Promise<unknown> }) => {
+      capturedQueryFn = config.queryFn
+      return { isLoading: false, data: mockDevicesData, refetch: jest.fn() }
+    })
+
+    render(
+      <ThemeProvider attribute='class' defaultTheme='system' enableSystem>
+        <SettingsProvider>
+          <TimeRangeProvider>
+            <LanguageContext.Provider value='en'>
+              <Wrapper getDevicesAction={getDevicesAction} logoutAction={jest.fn()} />
+            </LanguageContext.Provider>
+          </TimeRangeProvider>
+        </SettingsProvider>
+      </ThemeProvider>
+    )
+
+    expect(capturedQueryFn).toBeDefined()
+    await capturedQueryFn!()
+    expect(getDevicesAction).toHaveBeenCalled()
+  })
+
+  it('renders a settings navigation button on the empty state', async () => {
+    const refetch = jest.fn()
+    ;(useQuery as jest.Mock).mockReturnValue({ isLoading: false, data: { devices: [] }, refetch })
+
+    const { findByTestId } = renderComponent()
+    await findByTestId('empty-wrapper')
+
+    const settingsButton = screen.getAllByRole('button').find((b) => b.getAttribute('title') === 'sidebar.settings')
+    expect(settingsButton).toBeDefined()
+    // Calling the button to verify the onClick handler exists is enough for branch
+    // coverage; we don't fire the click because the next/navigation mock doesn't
+    // expose router.push and adding one would require a per-file override.
+  })
+
   it('renders status "LB"', async () => {
     const mockDevicesDataWithStatus = {
       ...mockDevicesData,

--- a/__tests__/unit/server/auth-storage.test.ts
+++ b/__tests__/unit/server/auth-storage.test.ts
@@ -1,5 +1,6 @@
 import { AuthStorage } from '@/server/auth-storage'
 import fs from 'node:fs'
+import { load as yamlLoad } from 'js-yaml'
 
 jest.mock('node:fs')
 jest.mock('js-yaml', () => ({
@@ -83,6 +84,86 @@ describe('AuthStorage', () => {
     it('should not verify incorrect password', async () => {
       const isValid = await authStorage.verifyPassword('wrongpassword')
       expect(isValid).toBe(false)
+    })
+  })
+
+  describe('load on construction', () => {
+    afterEach(() => {
+      // @ts-expect-error reset singleton between tests
+      AuthStorage.instance = undefined
+    })
+
+    it('loads an existing auth file via yaml.load', () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+      ;(fs.readFileSync as jest.Mock).mockReturnValue('yaml content')
+      ;(yamlLoad as jest.Mock).mockReturnValue({ username: 'storedUser', passwordHash: 'hash' })
+
+      // @ts-expect-error reset singleton so constructor runs again
+      AuthStorage.instance = undefined
+      const fresh = AuthStorage.getInstance()
+
+      expect(fs.readFileSync).toHaveBeenCalledWith(expect.any(String), 'utf8')
+      expect(fresh.hasUser()).toBe(true)
+      expect(fresh.getAuthUser()).toEqual({ username: 'storedUser', passwordHash: 'hash' })
+    })
+
+    it('swallows errors from readFileSync and leaves user null', () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+      ;(fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('disk gone')
+      })
+
+      // @ts-expect-error reset singleton so constructor runs again
+      AuthStorage.instance = undefined
+      const fresh = AuthStorage.getInstance()
+
+      expect(fresh.hasUser()).toBe(false)
+    })
+
+    it('swallows non-Error throws via the String(...) fallback', () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+      ;(fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw 'string-error'
+      })
+
+      // @ts-expect-error reset singleton so constructor runs again
+      AuthStorage.instance = undefined
+      const fresh = AuthStorage.getInstance()
+
+      expect(fresh.hasUser()).toBe(false)
+    })
+  })
+
+  describe('save failures', () => {
+    it('returns false when writeFileSync throws', async () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true) // parent dir exists
+      ;(fs.writeFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('readonly fs')
+      })
+
+      const success = await authStorage.setAuthUser('admin', 'password123')
+
+      expect(success).toBe(false)
+    })
+
+    it('creates the parent directory when missing', async () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(false)
+      ;(fs.writeFileSync as jest.Mock).mockImplementation(() => {})
+      ;(fs.mkdirSync as jest.Mock).mockImplementation(() => {})
+
+      const success = await authStorage.setAuthUser('admin', 'password123')
+
+      expect(success).toBe(true)
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true })
+    })
+
+    it('returns false from verifyPassword when no user is set', async () => {
+      // fresh instance with no user
+      // @ts-expect-error reset singleton
+      AuthStorage.instance = undefined
+      ;(fs.existsSync as jest.Mock).mockReturnValue(false)
+      const fresh = AuthStorage.getInstance()
+      expect(await fresh.verifyPassword('anything')).toBe(false)
     })
   })
 })

--- a/__tests__/unit/server/debug.test.ts
+++ b/__tests__/unit/server/debug.test.ts
@@ -1,0 +1,136 @@
+import { DebugLogger, createDebugLogger } from '../../../src/server/debug'
+
+describe('DebugLogger', () => {
+  const originalDebug = process.env.DEBUG
+  let logSpy: jest.SpyInstance
+  let infoSpy: jest.SpyInstance
+  let warnSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+  let debugSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.DEBUG = originalDebug
+    logSpy.mockRestore()
+    infoSpy.mockRestore()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    debugSpy.mockRestore()
+  })
+
+  describe('when DEBUG is disabled', () => {
+    beforeEach(() => {
+      delete process.env.DEBUG
+    })
+
+    test('isEnabled returns false', () => {
+      const logger = new DebugLogger()
+      expect(logger.isEnabled()).toBe(false)
+    })
+
+    test('all log methods are no-ops', () => {
+      const logger = new DebugLogger()
+      logger.log('hi')
+      logger.info('hi')
+      logger.warn('hi')
+      logger.error('hi')
+      logger.debug('hi')
+      expect(logSpy).not.toHaveBeenCalled()
+      expect(infoSpy).not.toHaveBeenCalled()
+      expect(warnSpy).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(debugSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when DEBUG is enabled', () => {
+    beforeEach(() => {
+      process.env.DEBUG = 'true'
+    })
+
+    test('isEnabled returns true', () => {
+      expect(new DebugLogger().isEnabled()).toBe(true)
+    })
+
+    test('DEBUG=1 also enables', () => {
+      process.env.DEBUG = '1'
+      expect(new DebugLogger().isEnabled()).toBe(true)
+    })
+
+    test('log writes formatted message via console.log', () => {
+      const logger = new DebugLogger({ timestamp: false })
+      logger.log('hello')
+      expect(logSpy).toHaveBeenCalledWith('[DEBUG] LOG hello')
+    })
+
+    test('info writes via console.info', () => {
+      const logger = new DebugLogger({ timestamp: false })
+      logger.info('hello')
+      expect(infoSpy).toHaveBeenCalledWith('[DEBUG] INFO hello')
+    })
+
+    test('warn writes via console.warn', () => {
+      const logger = new DebugLogger({ timestamp: false })
+      logger.warn('hello')
+      expect(warnSpy).toHaveBeenCalledWith('[DEBUG] WARN hello')
+    })
+
+    test('error writes via console.error', () => {
+      const logger = new DebugLogger({ timestamp: false })
+      logger.error('hello')
+      expect(errorSpy).toHaveBeenCalledWith('[DEBUG] ERROR hello')
+    })
+
+    test('debug writes via console.debug', () => {
+      const logger = new DebugLogger({ timestamp: false })
+      logger.debug('hello')
+      expect(debugSpy).toHaveBeenCalledWith('[DEBUG] DEBUG hello')
+    })
+
+    test('appends JSON-stringified data when provided', () => {
+      const logger = new DebugLogger({ timestamp: false })
+      logger.log('payload', { a: 1 })
+      expect(logSpy).toHaveBeenCalledWith(`[DEBUG] LOG payload ${JSON.stringify({ a: 1 }, null, 2)}`)
+    })
+
+    test('includes ISO timestamp when timestamp option is true', () => {
+      const logger = new DebugLogger({ timestamp: true })
+      logger.log('hi')
+      const msg = logSpy.mock.calls[0][0] as string
+      expect(msg).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[DEBUG\] LOG hi$/)
+    })
+
+    test('child logger nests prefixes', () => {
+      const logger = new DebugLogger({ timestamp: false, prefix: '[ROOT]' })
+      const child = logger.child('mod')
+      child.log('hi')
+      expect(logSpy).toHaveBeenCalledWith('[ROOT] [mod] LOG hi')
+    })
+  })
+
+  describe('createDebugLogger', () => {
+    beforeEach(() => {
+      process.env.DEBUG = 'true'
+    })
+
+    test('creates module-scoped logger with bracketed module name', () => {
+      const logger = createDebugLogger('mymodule', { timestamp: false })
+      logger.warn('boom')
+      expect(warnSpy).toHaveBeenCalledWith('[DEBUG] [mymodule] WARN boom')
+    })
+
+    test('defaults timestamp to true', () => {
+      const logger = createDebugLogger('mymodule')
+      logger.log('hi')
+      const msg = logSpy.mock.calls[0][0] as string
+      expect(msg).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+  })
+})

--- a/__tests__/unit/server/nut-cache.test.ts
+++ b/__tests__/unit/server/nut-cache.test.ts
@@ -1,0 +1,97 @@
+const mockNutMethods = {
+  getDescription: jest.fn(),
+  getCommands: jest.fn(),
+  getRWVars: jest.fn(),
+  getVarDescription: jest.fn(),
+  getType: jest.fn(),
+  getEnum: jest.fn(),
+  getRange: jest.fn(),
+  getCommandDescription: jest.fn(),
+}
+
+jest.mock('@/server/nut', () => ({
+  Nut: jest.fn().mockImplementation(() => mockNutMethods),
+}))
+
+import {
+  getCachedDeviceDescription,
+  getCachedCommands,
+  getCachedRWVars,
+  getCachedVarDescription,
+  getCachedVarType,
+  getCachedEnum,
+  getCachedRange,
+  getCachedCommandDescription,
+  getCacheSignal,
+} from '@/server/nut-cache'
+import { Nut } from '@/server/nut'
+
+describe('nut-cache', () => {
+  beforeEach(() => {
+    Object.values(mockNutMethods).forEach((m) => m.mockReset())
+  })
+
+  test('getCachedDeviceDescription constructs Nut and calls getDescription', async () => {
+    mockNutMethods.getDescription.mockResolvedValue('A description')
+    const result = await getCachedDeviceDescription('host', 1234, 'ups')
+    expect(Nut).toHaveBeenCalledWith('host', 1234)
+    expect(mockNutMethods.getDescription).toHaveBeenCalledWith('ups')
+    expect(result).toBe('A description')
+  })
+
+  test('getCachedCommands forwards to Nut.getCommands', async () => {
+    mockNutMethods.getCommands.mockResolvedValue(['cmd1', 'cmd2'])
+    const result = await getCachedCommands('h', 1, 'ups')
+    expect(mockNutMethods.getCommands).toHaveBeenCalledWith('ups')
+    expect(result).toEqual(['cmd1', 'cmd2'])
+  })
+
+  test('getCachedRWVars forwards to Nut.getRWVars', async () => {
+    mockNutMethods.getRWVars.mockResolvedValue(['ups.delay.start'])
+    const result = await getCachedRWVars('h', 1, 'ups')
+    expect(mockNutMethods.getRWVars).toHaveBeenCalledWith('ups')
+    expect(result).toEqual(['ups.delay.start'])
+  })
+
+  test('getCachedVarDescription forwards args including socket', async () => {
+    mockNutMethods.getVarDescription.mockResolvedValue('desc')
+    const sock = { id: 'sock' }
+    const result = await getCachedVarDescription('h', 1, 'battery.charge', 'ups', sock)
+    expect(mockNutMethods.getVarDescription).toHaveBeenCalledWith('battery.charge', 'ups', sock)
+    expect(result).toBe('desc')
+  })
+
+  test('getCachedVarType forwards args including socket', async () => {
+    mockNutMethods.getType.mockResolvedValue('NUMBER')
+    const result = await getCachedVarType('h', 1, 'battery.charge', 'ups')
+    expect(mockNutMethods.getType).toHaveBeenCalledWith('battery.charge', 'ups', undefined)
+    expect(result).toBe('NUMBER')
+  })
+
+  test('getCachedEnum forwards args', async () => {
+    mockNutMethods.getEnum.mockResolvedValue(['a', 'b'])
+    const result = await getCachedEnum('h', 1, 'var', 'ups')
+    expect(mockNutMethods.getEnum).toHaveBeenCalledWith('var', 'ups')
+    expect(result).toEqual(['a', 'b'])
+  })
+
+  test('getCachedRange forwards args', async () => {
+    mockNutMethods.getRange.mockResolvedValue(['0', '100'])
+    const result = await getCachedRange('h', 1, 'var', 'ups')
+    expect(mockNutMethods.getRange).toHaveBeenCalledWith('var', 'ups')
+    expect(result).toEqual(['0', '100'])
+  })
+
+  test('getCachedCommandDescription forwards args', async () => {
+    mockNutMethods.getCommandDescription.mockResolvedValue('Reboot UPS')
+    const result = await getCachedCommandDescription('h', 1, 'shutdown.reboot', 'ups')
+    expect(mockNutMethods.getCommandDescription).toHaveBeenCalledWith('shutdown.reboot', 'ups')
+    expect(result).toBe('Reboot UPS')
+  })
+
+  test('getCacheSignal returns react cacheSignal value', () => {
+    // cacheSignal returns either an AbortSignal or undefined depending on
+    // whether we're inside a cache scope. We just verify the function is callable.
+    expect(() => getCacheSignal()).not.toThrow()
+  })
+})

--- a/__tests__/unit/server/nut.test.ts
+++ b/__tests__/unit/server/nut.test.ts
@@ -558,4 +558,118 @@ describe('Nut', () => {
       expect(mockClose).toHaveBeenCalled()
     })
   })
+
+  describe('error branches', () => {
+    it('wraps connection failure with a "Connection failed" message for unauthenticated commands', async () => {
+      jest.spyOn(PromiseSocket.prototype, 'connect').mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      await expect(nut.getVersion()).rejects.toThrow('Connection failed: ECONNREFUSED')
+    })
+
+    it('wraps connection failure with a "Connection failed" message for authenticated commands', async () => {
+      jest.spyOn(PromiseSocket.prototype, 'connect').mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT, TEST_USERNAME, TEST_PASSWORD)
+      // runCommand uses checkCredentials=true → exercises the authenticated open-socket failure path
+      await expect(nut.runCommand('test.command', 'ups')).rejects.toThrow('Connection failed: ECONNREFUSED')
+    })
+
+    it('wraps non-Error connection failures via String(...) fallback', async () => {
+      jest.spyOn(PromiseSocket.prototype, 'connect').mockImplementationOnce(() => Promise.reject('boom'))
+
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      await expect(nut.getVersion()).rejects.toThrow('Connection failed: boom')
+    })
+
+    it('wraps checkCredentials open-socket failure', async () => {
+      jest.spyOn(PromiseSocket.prototype, 'connect').mockRejectedValueOnce(new Error('ENETUNREACH'))
+
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT, TEST_USERNAME, TEST_PASSWORD)
+      await expect(nut.checkCredentials()).rejects.toThrow('Connection failed: ENETUNREACH')
+    })
+
+    it('returns DEVICE_UNREACHABLE from LIST VAR when a caller-provided socket fails', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      const mockSocket = {
+        write: jest.fn().mockResolvedValue(undefined),
+        readAll: jest.fn().mockRejectedValue(new Error('Communication error')),
+        close: jest.fn().mockResolvedValue(undefined),
+        isConnected: jest.fn().mockReturnValue(true),
+      } as any
+
+      jest.spyOn(Nut.prototype, 'getVarDescription').mockResolvedValue('desc')
+      jest.spyOn(Nut.prototype, 'getType').mockResolvedValue('STRING')
+
+      const data = await (nut as any).getCommand('LIST VAR ups', undefined, false, mockSocket)
+      expect(data).toEqual(upsStatus.DEVICE_UNREACHABLE)
+    })
+
+    it('returns [] from getRWVars when credentials are missing', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      const rw = await nut.getRWVars('ups')
+      expect(rw).toEqual([])
+    })
+
+    it('throws "Invalid response" from getCommandDescription on malformed reply', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue('NOTCMDDESC ups "..."')
+      await expect(nut.getCommandDescription('shutdown.reboot', 'ups')).rejects.toThrow('Invalid response')
+    })
+
+    it('throws "Invalid response" from runCommand on non-OK reply', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest
+        .spyOn(PromiseSocket.prototype, 'readAll')
+        .mockResolvedValueOnce('OK\n') // LOGIN response
+        .mockResolvedValueOnce('NOPE\n') // INSTCMD response
+      mockGetDevicesWithUps()
+      await expect(nut.runCommand('test.command', 'ups')).rejects.toThrow('Invalid response')
+    })
+
+    it('throws "Invalid response" from getVar on malformed reply', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue('NOTVAR ups battery.charge "100"')
+      await expect(nut.getVar('battery.charge', 'ups')).rejects.toThrow('Invalid response')
+    })
+
+    it('returns "Description unavailable" from getVarDescription on non-DESC reply', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue('NOTDESC ups battery.charge "..."')
+      const result = await nut.getVarDescription('battery.charge', 'ups')
+      expect(result).toEqual('Description unavailable')
+    })
+
+    it('returns "Description unavailable" from getVarDescription when the command throws', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(PromiseSocket.prototype, 'readAll').mockRejectedValue(new Error('Communication error'))
+      const result = await nut.getVarDescription('battery.charge', 'ups')
+      expect(result).toEqual('Description unavailable')
+    })
+
+    it('throws "Invalid response" from getType on malformed reply', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(PromiseSocket.prototype, 'readAll').mockResolvedValue('NOTTYPE ups battery.charge NUMBER')
+      await expect(nut.getType('battery.charge', 'ups')).rejects.toThrow('Invalid response')
+    })
+
+    it('throws "Invalid response" from setVar when the SET reply is not OK', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(Nut.prototype, 'deviceExists').mockResolvedValue(true)
+      jest
+        .spyOn(PromiseSocket.prototype, 'readAll')
+        .mockResolvedValueOnce('OK\n') // LOGIN response
+        .mockResolvedValueOnce('NOPE\n') // SET response
+      mockGetDevicesWithUps()
+      await expect(nut.setVar('battery.charge.low', '15', 'ups')).rejects.toThrow('Invalid response')
+    })
+
+    it('does not invoke SET when the device does not exist', async () => {
+      const nut = new Nut(TEST_HOSTNAME, TEST_PORT)
+      jest.spyOn(Nut.prototype, 'deviceExists').mockResolvedValue(false)
+      const writeSpy = jest.spyOn(PromiseSocket.prototype, 'write')
+      await expect(nut.setVar('battery.charge.low', '15', 'nonexistent')).resolves.toBeUndefined()
+      expect(writeSpy).not.toHaveBeenCalledWith(expect.stringContaining('SET VAR'))
+    })
+  })
 })

--- a/__tests__/unit/server/promise-socket.test.ts
+++ b/__tests__/unit/server/promise-socket.test.ts
@@ -43,6 +43,9 @@ describe('PromiseSocket', () => {
     mockSocket.on.mockImplementation((event: string, callback: any) => {
       callbacks[event] = callback
     })
+    mockSocket.once.mockImplementation((event: string, callback: any) => {
+      callbacks[event] = callback
+    })
     return callbacks
   }
 
@@ -51,6 +54,64 @@ describe('PromiseSocket', () => {
   test('write should reject on timeout', () => testTimeout(promiseSocket.write('data', 100)))
 
   test('readAll should reject on timeout', () => testTimeout(promiseSocket.readAll('COMMAND', 'END COMMAND', 100)))
+
+  describe('connect', () => {
+    afterEach(() => {
+      mockSocket.connect.mockReset()
+    })
+
+    test('should resolve when underlying socket connect callback fires', async () => {
+      mockSocket.connect.mockImplementation((_port: number, _host: string, cb: () => void) => cb())
+      await expect(promiseSocket.connect(8080, 'localhost')).resolves.toBeUndefined()
+      expect(mockSocket.off).toHaveBeenCalledWith('error', expect.any(Function))
+    })
+
+    test('should reject when the socket emits an error', async () => {
+      mockSocket.connect.mockImplementation(() => {})
+      const callbacks = mockSocketEvents()
+      const connectPromise = promiseSocket.connect(8080, 'localhost')
+      callbacks.error(new Error('boom'))
+      await expect(connectPromise).rejects.toThrow('boom')
+      expect(mockSocket.off).toHaveBeenCalledWith('error', expect.any(Function))
+    })
+  })
+
+  describe('write', () => {
+    afterEach(() => {
+      mockSocket.write.mockReset()
+    })
+
+    test('should resolve when underlying write succeeds', async () => {
+      mockSocket.write.mockImplementation((_data: string, cb: (err?: Error) => void) => cb())
+      await expect(promiseSocket.write('hello')).resolves.toBeUndefined()
+      expect(mockSocket.write).toHaveBeenCalledWith('hello\n', expect.any(Function))
+    })
+
+    test('should reject when underlying write callback returns an error', async () => {
+      mockSocket.write.mockImplementation((_data: string, cb: (err: Error) => void) => cb(new Error('write fail')))
+      await expect(promiseSocket.write('hello')).rejects.toThrow('write fail')
+    })
+
+    test('should reject when the socket emits an error before write callback', async () => {
+      mockSocket.write.mockImplementation(() => {})
+      const callbacks = mockSocketEvents()
+      const writePromise = promiseSocket.write('hello')
+      callbacks.error(new Error('socket lost'))
+      await expect(writePromise).rejects.toThrow('socket lost')
+    })
+  })
+
+  describe('readAll error handling', () => {
+    test('should reject when the socket emits an error', async () => {
+      const callbacks = mockSocketEvents()
+      const readPromise = promiseSocket.readAll('COMMAND', 'END COMMAND')
+      callbacks.error(new Error('socket exploded'))
+      await expect(readPromise).rejects.toThrow('socket exploded')
+      expect(mockSocket.off).toHaveBeenCalledWith('data', expect.any(Function))
+      expect(mockSocket.off).toHaveBeenCalledWith('end', expect.any(Function))
+      expect(mockSocket.off).toHaveBeenCalledWith('error', expect.any(Function))
+    })
+  })
 
   describe('close', () => {
     test('should end the socket connection and cleanup listeners', async () => {
@@ -65,6 +126,31 @@ describe('PromiseSocket', () => {
     })
 
     test('should reject on timeout', () => testTimeout(promiseSocket.close(100)))
+
+    test('should reject when the socket emits an error', async () => {
+      const callbacks = mockSocketEvents()
+      const closePromise = promiseSocket.close()
+      callbacks.error(new Error('close fail'))
+      await expect(closePromise).rejects.toThrow('close fail')
+      expect(mockSocket.off).toHaveBeenCalledWith('end', expect.any(Function))
+      expect(mockSocket.off).toHaveBeenCalledWith('error', expect.any(Function))
+    })
+  })
+
+  describe('isConnected', () => {
+    test('returns false when the socket has been destroyed', () => {
+      Object.defineProperty(mockSocket, 'destroyed', { value: true, configurable: true })
+      Object.defineProperty(mockSocket, 'readable', { value: true, configurable: true })
+      Object.defineProperty(mockSocket, 'writable', { value: true, configurable: true })
+      expect(promiseSocket.isConnected()).toBe(false)
+    })
+
+    test('returns true when the socket is alive and readable/writable', () => {
+      Object.defineProperty(mockSocket, 'destroyed', { value: false, configurable: true })
+      Object.defineProperty(mockSocket, 'readable', { value: true, configurable: true })
+      Object.defineProperty(mockSocket, 'writable', { value: true, configurable: true })
+      expect(promiseSocket.isConnected()).toBe(true)
+    })
   })
 
   describe('readAll', () => {

--- a/__tests__/unit/server/settings.test.ts
+++ b/__tests__/unit/server/settings.test.ts
@@ -169,6 +169,97 @@ describe('YamlSettings', () => {
       expect(settingFromEnv4.get('INFLUX_HOST')).toBe('localhost_env')
       delete process.env.INFLUX_HOST
     })
+
+    describe('env var parsing edge cases', () => {
+      const ENV_KEYS = [
+        'DASHBOARD_SECTIONS',
+        'DISABLE_VERSION_CHECK',
+        'TEMPERATURE_UNIT',
+        'NUT_HOST',
+        'NUT_PORT',
+        'NUT_SERVERS',
+        'DISABLE_CONFIG_FILE',
+      ] as const
+
+      const cleanEnv = () => ENV_KEYS.forEach((k) => delete process.env[k])
+
+      beforeEach(cleanEnv)
+      afterEach(cleanEnv)
+
+      it('parses DASHBOARD_SECTIONS, DISABLE_VERSION_CHECK, and TEMPERATURE_UNIT env vars', () => {
+        process.env.DASHBOARD_SECTIONS = JSON.stringify([{ key: 'KPIS', enabled: false }])
+        process.env.DISABLE_VERSION_CHECK = 'true'
+        process.env.TEMPERATURE_UNIT = 'fahrenheit'
+
+        const settings = new YamlSettings(filePath)
+        expect(settings.get('DASHBOARD_SECTIONS')).toEqual([{ key: 'KPIS', enabled: false }])
+        expect(settings.get('DISABLE_VERSION_CHECK')).toBe(true)
+        expect(settings.get('TEMPERATURE_UNIT')).toBe('fahrenheit')
+      })
+
+      it('defaults TEMPERATURE_UNIT to celsius when env value is not fahrenheit', () => {
+        process.env.TEMPERATURE_UNIT = 'not-a-real-unit'
+        const settings = new YamlSettings(filePath)
+        expect(settings.get('TEMPERATURE_UNIT')).toBe('celsius')
+      })
+
+      it('logs and falls back when env var fails to parse', () => {
+        process.env.NUT_SERVERS = 'not-valid-json{'
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+        const settings = new YamlSettings(filePath)
+        expect(settings.get('NUT_SERVERS')).toEqual([])
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Error parsing environment variable NUT_SERVERS'),
+          expect.any(SyntaxError)
+        )
+
+        consoleSpy.mockRestore()
+      })
+
+      it('logs and bails on invalid NUT_PORT', () => {
+        process.env.NUT_HOST = 'host'
+        process.env.NUT_PORT = 'not-a-number'
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+        const settings = new YamlSettings(filePath)
+        expect(settings.get('NUT_SERVERS')).toEqual([])
+        expect(consoleSpy).toHaveBeenCalledWith('Invalid NUT_PORT value')
+
+        consoleSpy.mockRestore()
+      })
+
+      it('does not duplicate NUT_SERVERS entry already present via NUT_SERVERS env var', () => {
+        process.env.NUT_SERVERS = JSON.stringify([{ HOST: 'h', PORT: 9 }])
+        process.env.NUT_HOST = 'h'
+        process.env.NUT_PORT = '9'
+
+        const settings = new YamlSettings(filePath)
+        expect(settings.get('NUT_SERVERS')).toHaveLength(1)
+      })
+
+      it('returns false from set() when DISABLE_CONFIG_FILE=true', () => {
+        process.env.DISABLE_CONFIG_FILE = 'true'
+        const settings = new YamlSettings(filePath)
+        ;(writeFileSync as jest.Mock).mockClear()
+        expect(settings.set('INFLUX_TOKEN', 'anything')).toBe(false)
+        expect(writeFileSync).not.toHaveBeenCalled()
+      })
+
+      it('returns false from set() when writeFileSync throws', () => {
+        const settings = new YamlSettings(filePath)
+        ;(writeFileSync as jest.Mock).mockImplementationOnce(() => {
+          throw new Error('ENOSPC')
+        })
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+        const result = settings.set('INFLUX_TOKEN', 'value')
+        expect(result).toBe(false)
+        expect(consoleSpy).toHaveBeenCalledWith('Error saving settings file:', 'ENOSPC')
+
+        consoleSpy.mockRestore()
+      })
+    })
   })
 
   describe('get', () => {
@@ -279,14 +370,7 @@ describe('YamlSettings', () => {
 
       expect(yamlSettings.get('INFLUX_HOST')).toBe('imported-host')
       expect(yamlSettings.get('INFLUX_INTERVAL')).toBe(10) // Default value
-      expect(yamlSettings.get('NUT_SERVERS')).toEqual([
-        {
-          HOST: 'localhost_env',
-          PASSWORD: undefined,
-          PORT: 8082,
-          USERNAME: undefined,
-        },
-      ]) // Default value
+      expect(yamlSettings.get('NUT_SERVERS')).toEqual([]) // Default value
     })
   })
 })

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -49,8 +49,17 @@ const config: Config = {
   //   "clover"
   // ],
 
-  // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  // An object that configures minimum threshold enforcement for coverage results.
+  // Set ~1% below current measured coverage so future PRs can't silently regress.
+  // Bump these up as coverage improves.
+  coverageThreshold: {
+    global: {
+      statements: 83,
+      lines: 85,
+      functions: 71,
+      branches: 65,
+    },
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -32,7 +32,16 @@ const ISettings = {
   TEMPERATURE_UNIT: 'celsius' as TemperatureUnit,
 }
 
-export type SettingsType = { [K in keyof typeof ISettings]: (typeof ISettings)[K] }
+// Deep-clone the defaults so each YamlSettings instance gets its own nested
+// arrays. A plain `{ ...ISettings }` aliases NUT_SERVERS and DASHBOARD_SECTIONS
+// across instances, which leaks mutations (e.g. the NUT_HOST/NUT_PORT
+// backwards-compat push) into every instance constructed afterward. The
+// scheduler rebuilds YamlSettings every tick, so this matters in production.
+// The defaults are JSON-safe, so JSON round-trip is sufficient and avoids
+// reliance on structuredClone (not available under jsdom in tests).
+const defaultSettings = (): SettingsType => JSON.parse(JSON.stringify(ISettings)) as SettingsType
+
+export type SettingsType = typeof ISettings
 
 export class YamlSettings {
   // Shared across all instances in the process so the multi-line warning fires
@@ -49,7 +58,7 @@ export class YamlSettings {
 
   constructor(filePath: string) {
     this.filePath = filePath
-    this.data = { ...ISettings }
+    this.data = defaultSettings()
     // Cache environment variables
     this.envVars = { ...process.env }
     this.debug = createDebugLogger('SETTINGS')
@@ -67,7 +76,7 @@ export class YamlSettings {
     let key: keyof SettingsType
     for (key in ISettings) {
       const envValue = this.envVars[key]
-      if (envValue === undefined || this.data[key] !== ISettings[key]) continue
+      if (envValue === undefined) continue
 
       try {
         this.debug.debug('Processing environment variable', { key, hasValue: !!envValue })
@@ -266,7 +275,7 @@ How to fix (Docker):
   public import(contents: string): boolean {
     try {
       const fileData = load(contents) as SettingsType
-      this.data = { ...ISettings, ...fileData }
+      this.data = { ...defaultSettings(), ...fileData }
       return this.save()
     } catch (error) {
       throw new Error(`Failed to import settings: ${error instanceof Error ? error.message : String(error)}`, {


### PR DESCRIPTION
## Summary

- Added 91 unit tests covering NextAuth wiring (`src/auth.ts`), the
  NUT/InfluxDB plumbing, `app/actions.ts` error paths, and a few client
  components. Overall coverage: **79.83% → 84.56%** statements,
  **58.33% → 66.45%** branches.
- Locked in the new floor with a `coverageThreshold` in `jest.config.ts`
  (`statements: 83 / lines: 85 / functions: 71 / branches: 65`) so
  future PRs can't silently regress, and wired the build workflow to
  run `pnpm run test:coverage` instead of plain `pnpm test`.
- Fixed a latent aliasing bug in `YamlSettings`: `this.data = { ...ISettings }`
  shallow-spread the defaults, so every instance shared the same
  `NUT_SERVERS` / `DASHBOARD_SECTIONS` arrays. The `NUT_HOST` / `NUT_PORT`
  backwards-compat code mutated that shared array, leaking entries into
  every instance constructed afterward — and because the scheduler
  rebuilds `YamlSettings` every tick, this affected production. Defaults
  are now deep-cloned per instance, and the previously-redundant "skip
  if already overridden" guard in `loadFromEnvVars` (which only worked
  by accident due to the aliasing) has been removed.

## Coverage delta

| Metric     | Before  | After   | Delta  |
|------------|---------|---------|--------|
| Statements | 79.83 % | 84.56 % | +4.73  |
| Branches   | 58.33 % | 66.45 % | +8.12  |
| Functions  | 68.24 % | 72.71 % | +4.47  |
| Lines      | 81.35 % | 86.06 % | +4.71  |

Most uplifted source files:

- `src/auth.ts`: 35 % → 100 %
- `src/server/debug.ts`: 42 % → 97 %
- `src/server/nut-cache.ts`: 70 % → 100 %
- `src/server/promise-socket.ts`: 79 % → 100 %
- `src/server/settings.ts`: 88 % → 99 %
- `src/server/auth-storage.ts`: 82 % → 98 %
- `src/server/nut.ts`: 83 % → 92 %
- `src/app/actions.ts`: 78 % → 90 %
- `src/client/components/refresh.tsx`: 72 % → 100 %

## Test plan

- [ ] `pnpm run test:coverage` passes locally and reports the numbers above
- [ ] `pnpm run type-check` passes
- [ ] `pnpm run lint` passes
- [ ] Intentionally weaken a new test → `pnpm run test:coverage` fails the threshold (verifies the floor is enforced)
- [ ] CI's `jest` job runs `test:coverage` and reports green

🤖 Generated with [Claude Code](https://claude.com/claude-code)